### PR TITLE
Add PSC XY logging

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -885,6 +885,8 @@ void AC_PosControl::write_log()
     lean_angles_to_accel(accel_x, accel_y);
 
     AP::logger().Write_PSC(get_pos_target(), _inav.get_position(), get_vel_target(), _inav.get_velocity(), get_accel_target(), accel_x, accel_y);
+
+    AP::logger().Write_PSCP(_vel_error, _vel_xy_p, _vel_xy_i, _vel_xy_d);
 }
 
 /// init_vel_controller_xyz - initialise the velocity controller - should be called once before the caller attempts to use the controller
@@ -1059,7 +1061,7 @@ void AC_PosControl::run_xy_controller(float dt)
 
     // the following section converts desired velocities in lat/lon directions to accelerations in lat/lon frame
 
-    Vector2f accel_target, vel_xy_p, vel_xy_i, vel_xy_d;
+    Vector2f accel_target;
 
     // check if vehicle velocity is being overridden
     if (_flags.vehicle_horiz_vel_override) {
@@ -1078,22 +1080,22 @@ void AC_PosControl::run_xy_controller(float dt)
     _pid_vel_xy.set_input(_vel_error);
 
     // get p
-    vel_xy_p = _pid_vel_xy.get_p();
+    _vel_xy_p = _pid_vel_xy.get_p();
 
     // update i term if we have not hit the accel or throttle limits OR the i term will reduce
     // TODO: move limit handling into the PI and PID controller
     if (!_limit.accel_xy && !_motors.limit.throttle_upper) {
-        vel_xy_i = _pid_vel_xy.get_i();
+        _vel_xy_i = _pid_vel_xy.get_i();
     } else {
-        vel_xy_i = _pid_vel_xy.get_i_shrink();
+       _vel_xy_i = _pid_vel_xy.get_i_shrink();
     }
 
     // get d
-    vel_xy_d = _pid_vel_xy.get_d();
+    _vel_xy_d = _pid_vel_xy.get_d();
 
     // acceleration to correct for velocity error and scale PID output to compensate for optical flow measurement induced EKF noise
-    accel_target.x = (vel_xy_p.x + vel_xy_i.x + vel_xy_d.x) * ekfNavVelGainScaler;
-    accel_target.y = (vel_xy_p.y + vel_xy_i.y + vel_xy_d.y) * ekfNavVelGainScaler;
+    accel_target.x = (_vel_xy_p.x + _vel_xy_i.x + _vel_xy_d.x) * ekfNavVelGainScaler;
+    accel_target.y = (_vel_xy_p.y + _vel_xy_i.y + _vel_xy_d.y) * ekfNavVelGainScaler;
 
     // reset accel to current desired acceleration
     if (_flags.reset_accel_to_lean_xy) {

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -881,32 +881,10 @@ float AC_PosControl::time_since_last_xy_update() const
 // write log to dataflash
 void AC_PosControl::write_log()
 {
-    const Vector3f &pos_target = get_pos_target();
-    const Vector3f &vel_target = get_vel_target();
-    const Vector3f &accel_target = get_accel_target();
-    const Vector3f &position = _inav.get_position();
-    const Vector3f &velocity = _inav.get_velocity();
     float accel_x, accel_y;
     lean_angles_to_accel(accel_x, accel_y);
 
-    AP::logger().Write("PSC",
-                       "TimeUS,TPX,TPY,PX,PY,TVX,TVY,VX,VY,TAX,TAY,AX,AY",
-                       "smmmmnnnnoooo",
-                       "F000000000000",
-                       "Qffffffffffff",
-                       AP_HAL::micros64(),
-                       double(pos_target.x * 0.01f),
-                       double(pos_target.y * 0.01f),
-                       double(position.x * 0.01f),
-                       double(position.y * 0.01f),
-                       double(vel_target.x * 0.01f),
-                       double(vel_target.y * 0.01f),
-                       double(velocity.x * 0.01f),
-                       double(velocity.y * 0.01f),
-                       double(accel_target.x * 0.01f),
-                       double(accel_target.y * 0.01f),
-                       double(accel_x * 0.01f),
-                       double(accel_y * 0.01f));
+    AP::logger().Write_PSC(get_pos_target(), _inav.get_position(), get_vel_target(), _inav.get_velocity(), get_accel_target(), accel_x, accel_y);
 }
 
 /// init_vel_controller_xyz - initialise the velocity controller - should be called once before the caller attempts to use the controller

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -425,6 +425,9 @@ protected:
     Vector2f    _vehicle_horiz_vel;     // velocity to use if _flags.vehicle_horiz_vel_override is set
     LowPassFilterFloat _vel_error_filter;   // low-pass-filter on z-axis velocity error
 
+    // XY PID terms for logging
+    Vector2f _vel_xy_p, _vel_xy_i, _vel_xy_d;
+
     LowPassFilterVector2f _accel_target_filter; // acceleration target filter
 
     // ekf reset handling

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -283,6 +283,7 @@ public:
     void Write_SRTL(bool active, uint16_t num_points, uint16_t max_points, uint8_t action, const Vector3f& point);
     void Write_OABendyRuler(bool active, float target_yaw, float margin, const Location &final_dest, const Location &oa_dest);
     void Write_OADijkstra(uint8_t state, uint8_t error_id, uint8_t curr_point, uint8_t tot_points, const Location &final_dest, const Location &oa_dest);
+    void Write_PSC(const Vector3f &pos_target, const Vector3f &position, const Vector3f &vel_target, const Vector3f &velocity, const Vector3f &accel_target, const float &accel_x, const float &accel_y);
 
     void Write(const char *name, const char *labels, const char *fmt, ...);
     void Write(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -284,6 +284,7 @@ public:
     void Write_OABendyRuler(bool active, float target_yaw, float margin, const Location &final_dest, const Location &oa_dest);
     void Write_OADijkstra(uint8_t state, uint8_t error_id, uint8_t curr_point, uint8_t tot_points, const Location &final_dest, const Location &oa_dest);
     void Write_PSC(const Vector3f &pos_target, const Vector3f &position, const Vector3f &vel_target, const Vector3f &velocity, const Vector3f &accel_target, const float &accel_x, const float &accel_y);
+    void Write_PSCP(const Vector3f &vel_error, const Vector2f &vel_xy_p, const Vector2f &vel_xy_i, const Vector2f &vel_xy_d);
 
     void Write(const char *name, const char *labels, const char *fmt, ...);
     void Write(const char *name, const char *labels, const char *units, const char *mults, const char *fmt, ...);

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -1048,3 +1048,24 @@ void AP_Logger::Write_OADijkstra(uint8_t state, uint8_t error_id, uint8_t curr_p
     };
     WriteBlock(&pkt, sizeof(pkt));
 }
+
+void AP_Logger::Write_PSC(const Vector3f &pos_target, const Vector3f &position, const Vector3f &vel_target, const Vector3f &velocity, const Vector3f &accel_target, const float &accel_x, const float &accel_y)
+{
+    struct log_PSC pkt{
+        LOG_PACKET_HEADER_INIT(LOG_PSC_MSG),
+        time_us         : AP_HAL::micros64(),
+        pos_target_x    : pos_target.x * 0.01f,
+        pos_target_Y    : pos_target.y * 0.01f,
+        position_x      : position.x * 0.01f,
+        position_y      : position.y * 0.01f,
+        vel_target_x    : vel_target.x * 0.01f,
+        vel_target_y    : vel_target.y * 0.01f,
+        velocity_x      : velocity.x * 0.01f,
+        velocity_y      : velocity.y * 0.01f,
+        accel_target_x  : accel_target.x * 0.01f,
+        accel_target_y  : accel_target.y * 0.01f,
+        accel_x         : accel_x * 0.01f,
+        accel_y         : accel_y * 0.01f
+    };
+    WriteBlock(&pkt, sizeof(pkt));
+}

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -1069,3 +1069,20 @@ void AP_Logger::Write_PSC(const Vector3f &pos_target, const Vector3f &position, 
     };
     WriteBlock(&pkt, sizeof(pkt));
 }
+
+void AP_Logger::Write_PSCP(const Vector3f &vel_error, const Vector2f &vel_xy_p, const Vector2f &vel_xy_i, const Vector2f &vel_xy_d)
+{
+    struct log_PSCP pkt{
+        LOG_PACKET_HEADER_INIT(LOG_PSCP_MSG),
+        time_us     : AP_HAL::micros64(),
+        vel_error_x : vel_error.x * 0.01f,
+        vel_xy_p_x  : vel_xy_p.x,
+        vel_xy_i_x  : vel_xy_i.x,
+        vel_xy_d_x  : vel_xy_d.x,
+        vel_error_y : vel_error.y * 0.01f,
+        vel_xy_p_y  : vel_xy_p.y,
+        vel_xy_i_y  : vel_xy_i.y,
+        vel_xy_d_y  : vel_xy_d.y
+    };
+    WriteBlock(&pkt, sizeof(pkt));
+}

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1663,8 +1663,6 @@ struct PACKED log_PSCP {
       "VISO", "Qffffffff", "TimeUS,dt,AngDX,AngDY,AngDZ,PosDX,PosDY,PosDZ,conf", "ssrrrmmm-", "FF000000-" }, \
     { LOG_OPTFLOW_MSG, sizeof(log_Optflow), \
       "OF",   "QBffff",   "TimeUS,Qual,flowX,flowY,bodyX,bodyY", "s-EEEE", "F-0000" }, \
-    { LOG_WHEELENCODER_MSG, sizeof(log_WheelEncoder), \
-      "WENC",  "Qfbfb", "TimeUS,Dist0,Qual0,Dist1,Qual1", "sm-m-", "F0-0-" }, \
     { LOG_ADSB_MSG, sizeof(log_ADSB), \
       "ADSB",  "QIiiiHHhH", "TimeUS,ICAO_address,Lat,Lng,Alt,Heading,Hor_vel,Ver_vel,Squark", "s-DUmhnn-", "F-GGCBCC-" }, \
     { LOG_PSC_MSG, sizeof(log_PSC), \
@@ -1854,7 +1852,6 @@ enum LogMessages : uint8_t {
     LOG_PERFORMANCE_MSG,
     LOG_OPTFLOW_MSG,
     LOG_EVENT_MSG,
-    LOG_WHEELENCODER_MSG,
     LOG_MAV_MSG,
     LOG_ERROR_MSG,
     LOG_ADSB_MSG,

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1226,6 +1226,23 @@ struct PACKED log_Arm_Disarm {
     uint16_t arm_checks;
 };
 
+struct PACKED log_PSC {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float pos_target_x;
+    float pos_target_Y;
+    float position_x;
+    float position_y;
+    float vel_target_x;
+    float vel_target_y;
+    float velocity_x;
+    float velocity_y;
+    float accel_target_x;
+    float accel_target_y;
+    float accel_x;
+    float accel_y;
+};
+
 // FMT messages define all message formats other than FMT
 // UNIT messages define units which can be referenced by FMTU messages
 // FMTU messages associate types (e.g. centimeters/second/second) to FMT message fields
@@ -1311,6 +1328,22 @@ struct PACKED log_Arm_Disarm {
 #define ARSP_FMT "QffcffBBfB"
 #define ARSP_UNITS "snPOPP----"
 #define ARSP_MULTS "F00B00----"
+
+// @LoggerMessage: PSC
+// @Description: Position Control data
+// @Field: TimeUS: Time since system startup
+// @Field: TPX: Target position relative to origin, X-axis
+// @Field: TPY: Target position relative to origin, Y-axis
+// @Field: PX: Position relative to origin, X-axis
+// @Field: PY: Position relative to origin, Y-axis
+// @Field: TVX: Target velocity, X-axis
+// @Field: TVY: Target velocity, Y-axis
+// @Field: VX: Velocity, X-axis
+// @Field: VY: Velocity, Y-axis
+// @Field: TAX: Target acceleration, X-axis
+// @Field: TAY: Target acceleration, Y-axis
+// @Field: AX: Acceleration, X-axis
+// @Field: AY: Acceleration, Y-axis
 
 // messages for all boards
 #define LOG_BASE_STRUCTURES \
@@ -1608,8 +1641,9 @@ struct PACKED log_Arm_Disarm {
     { LOG_WHEELENCODER_MSG, sizeof(log_WheelEncoder), \
       "WENC",  "Qfbfb", "TimeUS,Dist0,Qual0,Dist1,Qual1", "sm-m-", "F0-0-" }, \
     { LOG_ADSB_MSG, sizeof(log_ADSB), \
-      "ADSB",  "QIiiiHHhH", "TimeUS,ICAO_address,Lat,Lng,Alt,Heading,Hor_vel,Ver_vel,Squark", "s-DUmhnn-", "F-GGCBCC-" }
-
+      "ADSB",  "QIiiiHHhH", "TimeUS,ICAO_address,Lat,Lng,Alt,Heading,Hor_vel,Ver_vel,Squark", "s-DUmhnn-", "F-GGCBCC-" }, \
+    { LOG_PSC_MSG, sizeof(log_PSC), \
+      "PSC", "Qffffffffffff", "TimeUS,TPX,TPY,PX,PY,TVX,TVY,VX,VY,TAX,TAY,AX,AY", "smmmmnnnnoooo", "F000000000000" }
 
 #define LOG_SBP_STRUCTURES \
     { LOG_MSG_SBPHEALTH, sizeof(log_SbpHealth), \
@@ -1800,6 +1834,7 @@ enum LogMessages : uint8_t {
     LOG_ARM_DISARM_MSG,
     LOG_OA_BENDYRULER_MSG,
     LOG_OA_DIJKSTRA_MSG,
+    LOG_PSC_MSG,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1243,6 +1243,19 @@ struct PACKED log_PSC {
     float accel_y;
 };
 
+struct PACKED log_PSCP {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float vel_error_x;
+    float vel_xy_p_x;
+    float vel_xy_i_x;
+    float vel_xy_d_x;
+    float vel_error_y;
+    float vel_xy_p_y;
+    float vel_xy_i_y;
+    float vel_xy_d_y;
+};
+
 // FMT messages define all message formats other than FMT
 // UNIT messages define units which can be referenced by FMTU messages
 // FMTU messages associate types (e.g. centimeters/second/second) to FMT message fields
@@ -1344,6 +1357,18 @@ struct PACKED log_PSC {
 // @Field: TAY: Target acceleration, Y-axis
 // @Field: AX: Acceleration, X-axis
 // @Field: AY: Acceleration, Y-axis
+
+// @LoggerMessage: PSCP
+// @Description: Position Control velocity PID gains
+// @Field: TimeUS: Time since system startup
+// @Field: EX: Velocity error, X-axis
+// @Field: kPX: Velocity P gain, X-axis
+// @Field: kIX: Velocity I gain, X-axis
+// @Field: kDX: Velocity D gain, X-axis
+// @Field: EY: Velocity error, Y-axis
+// @Field: kPY: Velocity P gain, Y-axis
+// @Field: kIY: Velocity I gain, Y-axis
+// @Field: kDY: Velocity D gain, Y-axis
 
 // messages for all boards
 #define LOG_BASE_STRUCTURES \
@@ -1643,7 +1668,9 @@ struct PACKED log_PSC {
     { LOG_ADSB_MSG, sizeof(log_ADSB), \
       "ADSB",  "QIiiiHHhH", "TimeUS,ICAO_address,Lat,Lng,Alt,Heading,Hor_vel,Ver_vel,Squark", "s-DUmhnn-", "F-GGCBCC-" }, \
     { LOG_PSC_MSG, sizeof(log_PSC), \
-      "PSC", "Qffffffffffff", "TimeUS,TPX,TPY,PX,PY,TVX,TVY,VX,VY,TAX,TAY,AX,AY", "smmmmnnnnoooo", "F000000000000" }
+      "PSC", "Qffffffffffff", "TimeUS,TPX,TPY,PX,PY,TVX,TVY,VX,VY,TAX,TAY,AX,AY", "smmmmnnnnoooo", "F000000000000" }, \
+    { LOG_PSCP_MSG, sizeof(log_PSCP), \
+      "PSCP", "Qffffffff", "TimeUS,EX,kPX,kIX,kDX,EY,kPY,kIY,kDY", "sn---n---", "F00000000"}
 
 #define LOG_SBP_STRUCTURES \
     { LOG_MSG_SBPHEALTH, sizeof(log_SbpHealth), \
@@ -1835,6 +1862,7 @@ enum LogMessages : uint8_t {
     LOG_OA_BENDYRULER_MSG,
     LOG_OA_DIJKSTRA_MSG,
     LOG_PSC_MSG,
+    LOG_PSCP_MSG,
 
     _LOG_LAST_MSG_
 };

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.cpp
@@ -201,15 +201,6 @@ void AP_WheelEncoder::Log_Write()
         return;
     }
 
-    struct log_WheelEncoder pkt = {
-        LOG_PACKET_HEADER_INIT(LOG_WHEELENCODER_MSG),
-        time_us     : AP_HAL::micros64(),
-        distance_0  : get_distance(0),
-        quality_0   : (uint8_t)get_signal_quality(0),
-        distance_1  : get_distance(1),
-        quality_1   : (uint8_t)get_signal_quality(1),
-    };
-    AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }
 
 // check if an instance is healthy


### PR DESCRIPTION
This PR adds logging messages for the PSC PID contributions in the XY controller.

Due to the number of logging messages in stable being close to 255 (uint8_t) I have removed the wheel encoder messages in separate commits to get the message count under 255.

Built and tested in SITL.