### PR TITLE
Increase the RC switch debounce time 

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -39,7 +39,7 @@ extern const AP_HAL::HAL& hal;
 #include <AP_GPS/AP_GPS.h>
 #include <AC_Fence/AC_Fence.h>
 
-#define SWITCH_DEBOUNCE_TIME_MS  200
+#define SWITCH_DEBOUNCE_TIME_MS  500
 
 const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Param: MIN


### PR DESCRIPTION
This PR increases the switch debounce time to half a second.

You can change it to whatever you like.  This PR is more just to show you where the define is.