### PR TITLE
Ac active weathervaning

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -973,7 +973,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: AUTO_OPTIONS
     // @DisplayName: Auto mode options
     // @Description: A range of options that can be applied to change auto mode behaviour. Allow Arming allows the copter to be armed in Auto. Allow Takeoff Without Raising Throttle allows takeoff without the pilot having to raise the throttle. Ignore pilot yaw overrides the pilot's yaw stick being used while in auto.
-    // @Bitmask: 0:Allow Arming,1:Allow Takeoff Without Raising Throttle,2:Ignore pilot yaw
+    // @Bitmask: 0:Allow Arming,1:Allow Takeoff Without Raising Throttle,2:Ignore pilot yaw,3:Allow weathervaning
     // @User: Advanced
     AP_GROUPINFO("AUTO_OPTIONS", 40, ParametersG2, auto_options, 0),
 #endif
@@ -982,7 +982,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: GUID_OPTIONS
     // @DisplayName: Guided mode options
     // @Description: Options that can be applied to change guided mode behaviour
-    // @Bitmask: 0:Allow Arming from Transmitter,2:Ignore pilot yaw
+    // @Bitmask: 0:Allow Arming from Transmitter,2:Ignore pilot yaw,3:Allow weathervaning
     // @User: Advanced
     AP_GROUPINFO("GUID_OPTIONS", 41, ParametersG2, guided_options, 0),
 #endif
@@ -995,6 +995,10 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("RTL_OPTIONS", 43, ParametersG2, rtl_options, 0),
 #endif
+
+    // @Group: WVANE
+    // @Path: ../libraries/AC_AttitudeControl/AC_WeatherVane.cpp
+    AP_SUBGROUPINFO(weathervane, "WVANE_", 44, ParametersG2, AC_WeatherVane),
 
     AP_GROUPEND
 };
@@ -1085,6 +1089,7 @@ ParametersG2::ParametersG2(void)
 #if MODE_AUTOROTATE_ENABLED == ENABLED
     ,arot(copter.inertial_nav)
 #endif
+    ,weathervane(copter.inertial_nav)
 {
     AP_Param::setup_object_defaults(this, var_info);
 }

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -2,6 +2,7 @@
 
 #include <AP_Common/AP_Common.h>
 #include "RC_Channel.h"
+#include <AC_AttitudeControl/AC_WeatherVane.h>
 
 #if GRIPPER_ENABLED == ENABLED
  # include <AP_Gripper/AP_Gripper.h>
@@ -635,6 +636,8 @@ public:
 #if MODE_RTL_ENABLED == ENABLED
     AP_Int32 rtl_options;
 #endif
+
+    AC_WeatherVane weathervane;
 
 };
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -387,9 +387,11 @@ private:
         AllowArming                        = (1 << 0U),
         AllowTakeOffWithoutRaisingThrottle = (1 << 1U),
         IgnorePilotYaw                     = (1 << 2U),
+        AllowWeatherVaning                 = (1 << 3U)
     };
 
     bool use_pilot_yaw(void) const;
+    bool allows_weathervaning(void) const;
 
     bool start_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command(const AP_Mission::Mission_Command& cmd);
@@ -811,9 +813,10 @@ private:
 
     // enum for GUID_OPTIONS parameter
     enum class Options : int32_t {
-        AllowArmingFromTX = (1U << 0),
+        AllowArmingFromTX   = (1U << 0),
         // this bit is still available, pilot yaw was mapped to bit 2 for symmetry with auto
-        IgnorePilotYaw    = (1U << 2),
+        IgnorePilotYaw      = (1U << 2),
+        AllowWeatherVaning  = (1U << 3)
     };
 
     void pos_control_start();
@@ -826,6 +829,7 @@ private:
     void set_desired_velocity_with_accel_and_fence_limits(const Vector3f& vel_des);
     void set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
     bool use_pilot_yaw(void) const;
+    bool allows_weathervaning(void) const;
 
     // controls which controller is run (pos or vel):
     GuidedMode guided_mode = Guided_TakeOff;

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -53,9 +53,6 @@ bool ModeAuto::init(bool ignore_checks)
             waiting_for_origin = true;
         }
 
-        // set max yaw rate in weather vane controller
-        copter.g2.weathervane.set_max_yaw_rate(attitude_control->get_yaw_rate_max());
-
         return true;
     } else {
         return false;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -327,7 +327,10 @@ public:
 
     // enable inverted flight on backends that support it
     virtual void set_inverted_flight(bool inverted) {}
-    
+
+    // Helper to access max yaw rate
+    float get_yaw_rate_max(void) { return _ang_vel_yaw_max.get(); }
+
     // User settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
@@ -1,0 +1,219 @@
+/*
+ * Aircraft Weathervane options common to vtol plane and copters
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include "AC_WeatherVane.h"
+#include <AP_Math/AP_Math.h>
+#include <GCS_MAVLink/GCS.h>
+#include <AP_Terrain/AP_Terrain.h>
+
+const AP_Param::GroupInfo AC_WeatherVane::var_info[] = {
+
+    // @Param: ENABLE
+    // @DisplayName: Enable
+    // @Description{Copter}: Enable weather vaning.  When active, and the appropriate _OPTIONS bit is set for auto, or guided, the aircraft will yaw into wind once the vehicle is above WVANE_MIN_ALT, is not moving, and there has been no pilot input for 3 seconds.
+    // @Description{Plane}: Enable weather vaning.  When active, the aircraft will automatically yaw into wind when in a VTOL position controlled mode. Pilot yaw commands overide the weathervaning action.
+    // @Values: 0:Disabled,1:Nose into wind,2:Nose or tail into wind (tailsitters)
+    // @User: Standard
+    AP_GROUPINFO_FLAGS("ENABLE", 1, AC_WeatherVane, _direction, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: GAIN
+    // @DisplayName: Weathervaning gain
+    // @Description: This controls the tendency to yaw to face into the wind. A value of 0.1 is to start with and will give a slow turn into the wind. Use a value of 0.4 for more rapid response. The weathervaning works by turning into the direction of roll.
+    // @Range: 0 2
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("GAIN", 2, AC_WeatherVane, _gain, 0.5),
+
+    // @Param: MIN_ANG
+    // @DisplayName: Weathervaning min angle
+    // @Description: The minimum angle error, in degrees, before active weathervaning will start.
+    // @Range: 0 10
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("MIN_ANG", 3, AC_WeatherVane, _min_dz_ang_deg, 1),
+
+    // @Param: MIN_ALT
+    // @DisplayName: Weathervaning min altitude
+    // @Description: Above this altitude weathervaning is permitted.  If terrain is enabled, AGL is used.  Set zero to ignore altitude.
+    // @Range: 0 50
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("MIN_ALT", 4, AC_WeatherVane, _min_alt, 2),
+
+    AP_GROUPEND
+};
+
+
+// Constructor
+AC_WeatherVane::AC_WeatherVane(const AP_InertialNav& inav) :
+    _inav(inav)
+{
+    reset();
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+bool AC_WeatherVane::get_yaw_rate_cds(float& yaw_rate, const int16_t pilot_yaw, const int16_t roll_cdeg, const int16_t pitch_cdeg)
+{
+    const uint32_t now = AP_HAL::millis();
+
+    // If it has been longer than 5 seconds since last call back then reset the controller
+    if (now - last_callback > 5000) {
+        reset();
+    }
+    last_callback = now;
+
+    if (!should_weathervane(pilot_yaw, roll_cdeg, pitch_cdeg, now)) {
+        return false;
+    }
+
+    if (!active_msg_sent) {
+        gcs().send_text(MAV_SEVERITY_INFO, "Weathervane Active");
+        active_msg_sent = true;
+    }
+
+    // Calculate new yaw rate
+    float output = fabsf(roll_cdeg) * _gain;
+
+    // For nose in only direction, we add nose up pitch contribution to maintain a 
+    // consistant yaw rate when the vehicle has its tail to the wind.
+    if (pitch_cdeg > 0 && get_direction() == Direction::NOSE_IN) {
+        output += pitch_cdeg * _gain;
+    }
+
+    /*
+      Determine yaw direction
+
+      If we can yaw nose or tail into wind we want to yaw in the direction
+      oppose to the roll angle when we have nose high attitudes. The nose
+      low behaviour is as per NOSE_IN behaviour.
+
+      At this point output only has magnitude, not direction.
+    */
+    if (pitch_cdeg > 0 && get_direction() == Direction::NOSE_OR_TAIL_IN) {
+        if (roll_cdeg > 0) {
+            output *= -1.0f;
+        } // else roll will be negative and we want the output to be positive
+
+    } else if (pitch_cdeg < 0 || get_direction() == Direction::NOSE_IN) {
+        // Yaw in the direction of the lowest 'wing'
+        if (roll_cdeg < 0) {
+            output *= -1.0f;
+        }
+    }
+
+    // Force the controller to relax.  This can be called when landing.
+    if (should_relax) {
+        output = 0;
+        // Always reset should relax. Maintain relaxed condition by persistant calls to relax()
+        should_relax = false;
+    }
+
+    // Slew output
+    last_output = 0.98f * last_output + 0.02f * output;
+
+    // Limit yaw rate if limits are set
+    if (!is_zero(yaw_rate_max_deg_s)) {
+        last_output = constrain_float(last_output, -yaw_rate_max_deg_s, yaw_rate_max_deg_s);
+    }
+
+    yaw_rate = last_output;
+
+    return true;
+}
+
+// Called on an interupt to reset the weathervane controller
+void AC_WeatherVane::reset(void)
+{
+    last_output = 0;
+    active_msg_sent = false;
+    should_relax = false;
+    first_activate_ms = 0;
+}
+
+bool AC_WeatherVane::should_weathervane(int16_t pilot_yaw, int16_t roll_cdeg, int16_t pitch_cdeg, const uint32_t now)
+{
+    // Check enabled
+    if ((Direction)((uint8_t)_direction) == Direction::OFF){
+        reset();
+        return false;
+    }
+
+    // Don't activate weather vaning if less than deadzone angle
+    if (fabsf(roll_cdeg) < _min_dz_ang_deg*100.0f  &&  (pitch_cdeg > 0.0f || get_direction() != Direction::NOSE_IN)) {
+        reset();
+        return 0.0f;
+    }
+
+    // Don't fight pilot inputs
+    if (pilot_yaw != 0) {
+        last_pilot_input_ms = now;
+        reset();
+        return false;
+    }
+
+    // Only allow weather vaning if no input from pilot in last 3 seconds
+    if (now - last_pilot_input_ms < 3000) {
+        reset();
+        return false;
+    }
+
+    // Check if we are above the minimum altitude to weather vane
+    if (below_min_alt()) {
+        reset();
+        return false;
+    }
+
+    /*
+      Use a 2 second buffer to ensure weathervaning occurs once the vehicle has
+      clearly settled in an acceptable condition. This avoids weathervane
+      activation as soon as a wp is accepted
+    */
+    if (first_activate_ms == 0) {
+        first_activate_ms = now;
+    }
+    if (now - first_activate_ms < 2000){
+        return false;
+    }
+
+    // If we got this far then we should allow weathervaning
+    return true;
+}
+
+bool AC_WeatherVane::below_min_alt(void)
+{
+    // Check min altitude is set
+    if (_min_alt.get() <= 0) {
+        return false;
+    }
+
+#if AP_TERRAIN_AVAILABLE
+    AP_Terrain* terrain = AP_Terrain::get_singleton();
+    if (terrain != nullptr) {
+        float terr_alt = 0.0f;
+        if (terrain->enabled() && terrain->height_above_terrain(terr_alt, true) && terr_alt >= (float)_min_alt.get()) {
+            return false;
+        }
+    }
+#endif
+
+    if (_inav.get_altitude() >= (float)_min_alt.get()) {
+        return false;
+    }
+
+    return true;
+}
+
+AC_WeatherVane::Direction AC_WeatherVane::get_direction() const
+{
+    return (Direction)_direction.get();
+}
+
+// Get the AC_WeatherVane singleton
+AC_WeatherVane *AC_WeatherVane::get_singleton()
+{
+    return _singleton;
+}
+
+AC_WeatherVane *AC_WeatherVane::_singleton = nullptr;

--- a/libraries/AC_AttitudeControl/AC_WeatherVane.h
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.h
@@ -1,0 +1,74 @@
+#include <AP_Param/AP_Param.h>
+#include <AP_InertialNav/AP_InertialNav.h>
+
+// weather vane class
+class AC_WeatherVane {
+    public:
+
+        // Constructor
+        AC_WeatherVane(const AP_InertialNav& inav);
+
+        // Do not allow copies
+        AC_WeatherVane(const AC_WeatherVane &other) = delete;
+        AC_WeatherVane &operator=(const AC_WeatherVane&) = delete;
+
+        bool get_yaw_rate_cds(float& yaw_rate, const int16_t pilot_yaw, const int16_t roll_cdeg, const int16_t pitch_cdeg);
+
+        // Use to relax weather vaning on landing.  Must be persistantly called before calls to get_weathervane_yaw_rate_cds().
+        void set_relax(bool relax) { should_relax = relax; }
+
+        void set_max_yaw_rate(float rate_max) { yaw_rate_max_deg_s = rate_max; }
+
+        static AC_WeatherVane* get_singleton();
+
+        static const struct AP_Param::GroupInfo var_info[];
+
+    private:
+
+        // References to other libraries
+        const AP_InertialNav& _inav;
+
+        // Different options for the direction that vehicle will turn into wind
+        enum class Direction {
+            OFF = 0,
+            NOSE_IN = 1,
+            NOSE_OR_TAIL_IN = 2,
+            //TODO: Knife Edge for copter tailsitters
+        };
+
+        // Returns true if the vehicle is in a condition whereby weathervaning is allowed
+        bool should_weathervane(int16_t pilot_yaw, int16_t roll_cdeg, int16_t pitch_cdeg, const uint32_t now);
+
+        // Returns the set direction, handling the variable cast to type Direction
+        Direction get_direction(void) const;
+
+        // Function to reset all flags and set values. Involked whenever the weather vaning process is interupted
+        void reset(void);
+
+        /*
+          Check if vehicle is above the minimum altitude to weather vane.
+          Returns true if above the min set altitude.
+          Uses terrain altitude if it is enabled.
+        */
+        bool below_min_alt(void);
+
+        // Paramaters
+        AP_Int8 _direction;
+        AP_Float _gain;
+        AP_Float _min_dz_ang_deg;
+        AP_Int32 _min_alt;
+
+        uint32_t last_pilot_input_ms;
+        float last_output;
+        bool should_relax;
+        float yaw_rate_max_deg_s;
+        bool active_msg_sent;
+        uint32_t last_callback;
+        uint32_t first_activate_ms;
+
+        static AC_WeatherVane *_singleton;
+};
+
+namespace AP {
+    AC_WeatherVane *weathervane();
+};

--- a/libraries/AC_AttitudeControl/AC_WeatherVane.h
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.h
@@ -17,8 +17,6 @@ class AC_WeatherVane {
         // Use to relax weather vaning on landing.  Must be persistantly called before calls to get_weathervane_yaw_rate_cds().
         void set_relax(bool relax) { should_relax = relax; }
 
-        void set_max_yaw_rate(float rate_max) { yaw_rate_max_deg_s = rate_max; }
-
         static AC_WeatherVane* get_singleton();
 
         static const struct AP_Param::GroupInfo var_info[];


### PR DESCRIPTION
This PR adds two commits to patch the weathervaning yaw rate limit.  It:
- Removes the yaw rate limit check within the weathervane library.
- Adds weathervane log field.

The additional log message can be removed at a later date to minimise log size but has been included to help with debugging in DnR.

No parameter changes are required.  