### PR TITLE
copter: remove old wvane param group

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -996,10 +996,6 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_GROUPINFO("RTL_OPTIONS", 43, ParametersG2, rtl_options, 0),
 #endif
 
-    // @Group: WVANE
-    // @Path: ../libraries/AC_AttitudeControl/AC_WeatherVane.cpp
-    AP_SUBGROUPINFO(weathervane, "WVANE_", 44, ParametersG2, AC_WeatherVane),
-
     // @Group: WVANE_
     // @Path: ../libraries/AC_AttitudeControl/AC_WeatherVane.cpp
     AP_SUBGROUPINFO(weathervane, "WVANE_", 45, ParametersG2, AC_WeatherVane),


### PR DESCRIPTION
Fix for the param load issue Dan was experiencing on 22/05/2021