### PR TITLE
PWM input buttons

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -199,7 +199,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK(userhook_SuperSlowLoop, 1,   75),
 #endif
 #if BUTTON_ENABLED == ENABLED
-    SCHED_TASK_CLASS(AP_Button,            &copter.g2.button,           update,           5, 100),
+    SCHED_TASK_CLASS(AP_Button,            &copter.button,           update,           5, 100),
 #endif
 #if STATS_ENABLED == ENABLED
     SCHED_TASK_CLASS(AP_Stats,             &copter.g2.stats,            update,           1, 100),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -532,11 +532,6 @@ private:
     AP_Parachute parachute{relay};
 #endif
 
-    // Button 
-#if BUTTON_ENABLED == ENABLED
-    AP_Button button;
-#endif
-
     // Landing Gear Controller
     AP_LandingGear landinggear;
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -735,7 +735,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 #if BUTTON_ENABLED == ENABLED
     // @Group: BTN_
     // @Path: ../libraries/AP_Button/AP_Button.cpp
-    AP_SUBGROUPINFO(button, "BTN_", 2, ParametersG2, AP_Button),
+    AP_SUBGROUPPTR(button_ptr, "BTN_", 2, ParametersG2, AP_Button),
 #endif
 
 #if MODE_THROW_ENABLED == ENABLED
@@ -1090,6 +1090,7 @@ ParametersG2::ParametersG2(void)
     ,arot(copter.inertial_nav)
 #endif
     ,weathervane(copter.inertial_nav)
+    ,button_ptr(&copter.button)
 {
     AP_Param::setup_object_defaults(this, var_info);
 }

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -486,10 +486,8 @@ public:
     // altitude at which nav control can start in takeoff
     AP_Float wp_navalt_min;
 
-#if BUTTON_ENABLED == ENABLED
     // button checking
-    AP_Button button;
-#endif
+    AP_Button *button_ptr;
 
 #if STATS_ENABLED == ENABLED
     // vehicle statistics

--- a/libraries/AP_Button/AP_Button.cpp
+++ b/libraries/AP_Button/AP_Button.cpp
@@ -20,6 +20,8 @@
 
 extern const AP_HAL::HAL& hal;
 
+AP_Button *AP_Button::_singleton;
+
 const AP_Param::GroupInfo AP_Button::var_info[] = {
 
     // @Param: ENABLE
@@ -72,6 +74,11 @@ const AP_Param::GroupInfo AP_Button::var_info[] = {
 AP_Button::AP_Button(void)
 {
     AP_Param::setup_object_defaults(this, var_info);
+
+    if (_singleton != nullptr) {
+        AP_HAL::panic("AP_Button must be singleton");
+    }
+    _singleton = this;
 }
 
 /*
@@ -165,4 +172,13 @@ void AP_Button::setup_pins(void)
         // setup pullup
         hal.gpio->write(pin[i], 1);
     }
+}
+
+namespace AP {
+
+AP_Button &button()
+{
+    return *AP_Button::get_singleton();
+}
+
 }

--- a/libraries/AP_Button/AP_Button.cpp
+++ b/libraries/AP_Button/AP_Button.cpp
@@ -251,14 +251,7 @@ void AP_Button::run_aux_functions(bool force)
             state_actioned_mask &= ~value_mask;
         }
 
-        const RC_Channel::AuxSwitchPos pos = value ? RC_Channel::AuxSwitchPos::HIGH : RC_Channel::AuxSwitchPos::LOW;
-        // I wonder if we can do better here:
-#if !HAL_MINIMIZE_FEATURES
-        const char *str = rc_channel->string_for_aux_function(func);
-        if (str != nullptr) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Button: executing (%s)", str);
-        }
-#endif
+        const RC_Channel::aux_switch_pos_t pos = value ? RC_Channel::aux_switch_pos_t::HIGH : RC_Channel::aux_switch_pos_t::LOW;
         rc_channel->do_aux_function(func, pos);
     }
 }

--- a/libraries/AP_Button/AP_Button.h
+++ b/libraries/AP_Button/AP_Button.h
@@ -41,6 +41,10 @@ public:
         return _singleton;
     }
 
+    // get state of a button
+    // used by scripting
+    bool get_button_state(uint8_t number);
+
 private:
 
     static AP_Button *_singleton;
@@ -53,6 +57,9 @@ private:
 
     // last button press mask
     uint8_t last_mask;
+
+    // debounced button press mask
+    uint8_t debounce_mask;
 
     // when the mask last changed
     uint64_t last_change_time_ms;

--- a/libraries/AP_Button/AP_Button.h
+++ b/libraries/AP_Button/AP_Button.h
@@ -28,12 +28,23 @@ public:
     // constructor
     AP_Button(void);
 
+    /* Do not allow copies */
+    AP_Button(const AP_Button &other) = delete;
+    AP_Button &operator=(const AP_Button&) = delete;
+
     static const struct AP_Param::GroupInfo var_info[];
 
     // update button state and send messages, called periodically by main loop
     void update(void);
-    
+
+    static AP_Button *get_singleton(void) {
+        return _singleton;
+    }
+
 private:
+
+    static AP_Button *_singleton;
+
     AP_Int8 enable;
     AP_Int8 pin[AP_BUTTON_NUM_PINS];
 
@@ -65,3 +76,6 @@ private:
     void setup_pins();
 };
 
+namespace AP {
+    AP_Button &button();
+};

--- a/libraries/AP_Button/AP_Button.h
+++ b/libraries/AP_Button/AP_Button.h
@@ -56,6 +56,11 @@ private:
     bool is_pwm_input(uint8_t n) const {
         return ((uint8_t)options[n].get() & (1U<<0)) != 0;
     }
+    bool is_input_inverted(uint8_t n) const {
+        return ((uint8_t)options[n].get() & (1U<<1)) != 0;
+    }
+
+    AP_Int16 pin_func[AP_BUTTON_NUM_PINS];  // from the RC_Channel functions
 
     // number of seconds to send change notifications
     AP_Int16 report_send_time;
@@ -75,10 +80,25 @@ private:
     // pwm sources are used when using PWM on the input
     AP_HAL::PWMSource pwm_pin_source[AP_BUTTON_NUM_PINS];
 
+    // state from the timer interrupt:
+    HAL_Semaphore last_debounced_change_ms_sem;
+    // last time GPIO pins were debounced:
     uint64_t last_debounced_change_ms;
+
+    // time at least last debounce changes across both PWM and GPIO
+    // pins was detected:
+    uint64_t last_debounce_ms;
 
     // when the mask last changed
     uint64_t last_change_time_ms;
+
+    // when button change events were last actioned
+    uint64_t last_action_time_ms;
+
+    // true if allocated aux functions have been initialised
+    bool aux_functions_initialised;
+    // call init_aux_function for all used functions
+    void run_aux_functions(bool force);
 
     // time of last report
     uint32_t last_report_ms;

--- a/libraries/AP_Button/AP_Button.h
+++ b/libraries/AP_Button/AP_Button.h
@@ -51,6 +51,11 @@ private:
 
     AP_Int8 enable;
     AP_Int8 pin[AP_BUTTON_NUM_PINS];
+    AP_Int8 options[AP_BUTTON_NUM_PINS];  // if a pin's bit is set then it uses PWM assertion
+
+    bool is_pwm_input(uint8_t n) const {
+        return ((uint8_t)options[n].get() & (1U<<0)) != 0;
+    }
 
     // number of seconds to send change notifications
     AP_Int16 report_send_time;
@@ -60,6 +65,17 @@ private:
 
     // debounced button press mask
     uint8_t debounce_mask;
+
+    // current state of PWM pins:
+    uint8_t pwm_state;
+
+    // mask indicating which action was most recent taken for pins
+    uint8_t state_actioned_mask;
+
+    // pwm sources are used when using PWM on the input
+    AP_HAL::PWMSource pwm_pin_source[AP_BUTTON_NUM_PINS];
+
+    uint64_t last_debounced_change_ms;
 
     // when the mask last changed
     uint64_t last_change_time_ms;

--- a/libraries/AP_HAL/AP_HAL_Namespace.h
+++ b/libraries/AP_HAL/AP_HAL_Namespace.h
@@ -22,6 +22,7 @@ namespace AP_HAL {
     class AnalogIn;
     class Storage;
     class DigitalSource;
+    class PWMSource;
     class GPIO;
     class RCInput;
     class RCOutput;

--- a/libraries/AP_HAL/GPIO.cpp
+++ b/libraries/AP_HAL/GPIO.cpp
@@ -1,0 +1,108 @@
+#include "GPIO.h"
+
+#include <AP_HAL/AP_HAL.h>
+#if defined(HAL_NO_GCS) || defined(HAL_BOOTLOADER_BUILD)
+#define GCS_SEND_TEXT(severity, format, args...)
+#else
+#include <GCS_MAVLink/GCS.h>
+#endif
+
+extern const AP_HAL::HAL& hal;
+
+bool AP_HAL::PWMSource::set_pin(int16_t new_pin, const char *subsystem)
+{
+    if (new_pin == _pin) {
+        // we've already tried to attach to this pin
+        return interrupt_attached;
+    }
+
+    if (interrupt_attached) {
+        if (!hal.gpio->detach_interrupt(_pin)) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING,
+                          "%s: Failed to detach interrupt from %d",
+                          subsystem,
+                          _pin);
+        }
+        interrupt_attached = false;
+    }
+
+    // don't want to try to attach more than once:
+    _pin = new_pin;
+
+    if (_pin <= 0) {
+        // invalid pin
+        return false;
+    }
+
+    // install interrupt handler on rising and falling edge
+    hal.gpio->pinMode(_pin, HAL_GPIO_INPUT);
+    if (!hal.gpio->attach_interrupt(
+            _pin,
+            FUNCTOR_BIND_MEMBER(&AP_HAL::PWMSource::irq_handler,
+                                void,
+                                uint8_t,
+                                bool,
+                                uint32_t),
+            AP_HAL::GPIO::INTERRUPT_BOTH)) {
+        // failed to attach interrupt
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING,
+                      "%s: Failed to attach interrupt to %d",
+                      subsystem,
+                      _pin);
+        return false;
+    }
+
+    interrupt_attached = true;
+
+    return interrupt_attached;
+}
+
+// interrupt handler for reading pwm value
+void AP_HAL::PWMSource::irq_handler(uint8_t a_pin, bool pin_high, uint32_t timestamp_us)
+{
+    if (pin_high) {
+        _pulse_start_us = timestamp_us;
+        return;
+    }
+    if (_pulse_start_us == 0) {
+        // if we miss interrupts we could get two lows in a row.  If
+        // we miss interrupts we're definitely handing back bad
+        // values anyway....
+        return;
+    }
+    _irq_value_us = timestamp_us - _pulse_start_us;
+    _pulse_start_us = 0;
+
+    // update fields for taking an average reading:
+    _irq_value_us_sum += _irq_value_us;
+    _irq_value_us_count++;
+}
+
+
+uint16_t AP_HAL::PWMSource::get_pwm_us()
+{
+    // disable interrupts and grab state
+    void *irqstate = hal.scheduler->disable_interrupts_save();
+    const uint32_t ret = _irq_value_us;
+    _irq_value_us = 0;
+    hal.scheduler->restore_interrupts(irqstate);
+
+    return ret;
+}
+
+uint16_t AP_HAL::PWMSource::get_pwm_avg_us()
+{
+    // disable interrupts and grab state
+    void *irqstate = hal.scheduler->disable_interrupts_save();
+    uint32_t ret;
+    if (_irq_value_us_count == 0) {
+        ret = 0;
+    } else {
+        ret = _irq_value_us_sum / _irq_value_us_count;
+    }
+    _irq_value_us_sum = 0;
+    _irq_value_us_count = 0;
+    hal.scheduler->restore_interrupts(irqstate);
+
+    return ret;
+}

--- a/libraries/AP_HAL/GPIO.h
+++ b/libraries/AP_HAL/GPIO.h
@@ -16,6 +16,31 @@ public:
     virtual void    toggle() = 0;
 };
 
+class AP_HAL::PWMSource {
+public:
+
+    bool set_pin(int16_t new_pin, const char *subsystem);
+    int16_t pin() const { return _pin; }  // returns pin this is attached to
+
+    uint16_t get_pwm_us();            // return last measured PWM input
+    uint16_t get_pwm_avg_us();        // return average PWM since last call to get_pwm_avg_us
+
+private:
+    uint16_t _irq_value_us;         // last calculated pwm value (irq copy)
+    uint32_t _pulse_start_us;       // system time of start of pulse
+    int16_t _pin = -1;
+
+    uint32_t _irq_value_us_sum;     // for get_pwm_avg_us
+    uint32_t _irq_value_us_count;   // for get_pwm_avg_us
+
+    bool interrupt_attached;
+
+    // PWM input handling
+    void irq_handler(uint8_t pin,
+                     bool pin_state,
+                     uint32_t timestamp);
+};
+
 class AP_HAL::GPIO {
 public:
     GPIO() {}

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -186,7 +186,11 @@ public:
     };
     typedef enum AUX_FUNC aux_func_t;
 
-protected:
+
+    // pwm value above which the option will be invoked:
+    static const uint16_t AUX_PWM_TRIGGER_HIGH = 1800;
+    // pwm value below which the option will be disabled:
+    static const uint16_t AUX_PWM_TRIGGER_LOW = 1200;
 
     // auxillary switch handling (n.b.: we store this as 2-bits!):
     enum aux_switch_pos_t : uint8_t {
@@ -195,8 +199,11 @@ protected:
         HIGH       // indicates auxiliary switch is in the high position (pwm >1800)
     };
 
-    virtual void init_aux_function(aux_func_t ch_option, aux_switch_pos_t);
     virtual void do_aux_function(aux_func_t ch_option, aux_switch_pos_t);
+
+protected:
+
+    virtual void init_aux_function(aux_func_t ch_option, aux_switch_pos_t);
 
     void do_aux_function_avoid_proximity(const aux_switch_pos_t ch_flag);
     void do_aux_function_camera_trigger(const aux_switch_pos_t ch_flag);
@@ -213,7 +220,6 @@ protected:
     virtual void mode_switch_changed(modeswitch_pos_t new_pos) {
         // no action by default (e.g. Tracker, Sub, who do their own thing)
     };
-
 
 private:
 
@@ -243,10 +249,6 @@ private:
     int16_t pwm_to_angle() const;
     int16_t pwm_to_angle_dz(uint16_t dead_zone) const;
 
-    // pwm value above which the option will be invoked:
-    static const uint16_t AUX_PWM_TRIGGER_HIGH = 1800;
-    // pwm value below which the option will be disabled:
-    static const uint16_t AUX_PWM_TRIGGER_LOW = 1200;
     bool read_3pos_switch(aux_switch_pos_t &ret) const WARN_IF_UNUSED;
 
     // Structure used to detect and debounce switch changes


### PR DESCRIPTION
This adds the ability for button to perform a RC option and be activated by a PWM.

The setup would be:
```
BTN_ENABLE = 1
BTN_FUNC1 = 81 (disarm)
BTN_OPTIONS1 = 1 (PWM in)
BTN_PIN1 = a pin number
```

You may also have to decrease `BRD_PWM_COUNT` depending on what pin you need and what your using elsewhere.

