### PR TITLE
AP_Parachute: refactor releae logic to start at and return to min PWM

### DIFF
--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -211,13 +211,14 @@ void AP_Parachute::update()
         send_msg();
     }
 
-    // exit immediately if not enabled or parachute not to be released
-    if (_enabled <= 0 || _cancel_timeout_ms == 0) {
+    // exit immediately if not enabled 
+    if (_enabled <= 0) {
         return;
     }
 
-    // wait for a possible cancel
-    if (now < _cancel_timeout_ms) {
+    // parachute not to be released or waiting for a possible cancel
+    if ( (_cancel_timeout_ms == 0) || (now < _cancel_timeout_ms)) {
+        release_off();
         return;
     }
 
@@ -230,13 +231,13 @@ void AP_Parachute::update()
         // just send text and write to log, do not actually do anything
         // usefull for testing thresholds are not exceeded in normal flight
         _cancel_timeout_ms = 0;
+        release_off();
         return;
     }
 
     // set release time to current system time
     if (_release_time == 0) {
         _release_time = now;
-        _release_setup = false;
     }
 
     _release_initiated = true;
@@ -249,7 +250,7 @@ void AP_Parachute::update()
     uint32_t delay_ms = _delay_ms<=0 ? 0: (uint32_t)_delay_ms;
     
     // check if we should release parachute
-    if ((_release_time != 0) && !_release_in_progress) {
+    if (!_release_setup || !_release_in_progress) {
         if (!_release_setup) {
             if ((_options & DONT_DEPLOY_LANDING_GEAR) == 0) {
                 // deploy landing gear
@@ -268,28 +269,37 @@ void AP_Parachute::update()
             if (_release_type == AP_PARACHUTE_TRIGGER_TYPE_SERVO) {
                 // move servo
                 SRV_Channels::set_output_pwm(SRV_Channel::k_parachute_release, _servo_on_pwm);
-            }else if (_release_type <= AP_PARACHUTE_TRIGGER_TYPE_RELAY_3) {
+            } else if (_release_type <= AP_PARACHUTE_TRIGGER_TYPE_RELAY_3) {
                 // set relay
                 _relay.on(_release_type);
             }
             _release_in_progress = true;
-            _released = true;
         }
-    }else if ((_release_time == 0) || time_diff >= delay_ms + AP_PARACHUTE_RELEASE_DURATION_MS) {
-        if (_release_type == AP_PARACHUTE_TRIGGER_TYPE_SERVO) {
-            // move servo back to off position
-            SRV_Channels::set_output_pwm(SRV_Channel::k_parachute_release, _servo_off_pwm);
-        }else if (_release_type <= AP_PARACHUTE_TRIGGER_TYPE_RELAY_3) {
-            // set relay back to zero volts
-            _relay.off(_release_type);
-        }
+    } else if (time_diff >= delay_ms + AP_PARACHUTE_RELEASE_DURATION_MS) {
+        release_off();
+
         // reset released flag and release_time
         _release_in_progress = false;
+        _release_setup = false;
         _release_time = 0;
+        _cancel_timeout_ms = 0;
+
         // update AP_Notify
         AP_Notify::flags.parachute_release = 0;
     }
 }
+
+void AP_Parachute::release_off()
+{
+    if (_release_type == AP_PARACHUTE_TRIGGER_TYPE_SERVO) {
+        // move servo back to off position
+        SRV_Channels::set_output_pwm(SRV_Channel::k_parachute_release, _servo_off_pwm);
+    } else if (_release_type <= AP_PARACHUTE_TRIGGER_TYPE_RELAY_3) {
+        // set relay back to zero volts
+        _relay.off(_release_type);
+    }
+}
+
 
 // update - set vehicle sink rate and accel
 void AP_Parachute::update(const float sink_rate, const float accel, const bool throttle_below_hover)

--- a/libraries/AP_Parachute/AP_Parachute.h
+++ b/libraries/AP_Parachute/AP_Parachute.h
@@ -66,9 +66,6 @@ public:
     /// release - release parachute
     void release(release_reason reason);
 
-    /// released - true if the parachute has been released (or release is in progress)
-    bool released() const { return _released; }
-    
     /// release_initiated - true if the parachute release sequence has been initiated (may wait before actual release)
     bool release_initiated() const { return _release_initiated; }
 
@@ -108,6 +105,9 @@ private:
     // send user command long updating the parchute status
     void send_msg();
 
+    // Set servo or relay to off position
+    void release_off();
+
     // Structure to lookup for release reasons
     struct LookupTable{
        release_reason option;
@@ -143,7 +143,6 @@ private:
     bool        _release_initiated:1;    // true if the parachute release initiated (may still be waiting for engine to be suppressed etc.)
     bool        _release_setup:1;        // true if parchute release has been setup (vehicle disarmed, landing gear deployed)
     bool        _release_in_progress:1;  // true if the parachute release is in progress
-    bool        _released:1;             // true if the parachute has been released
     bool        _is_flying:1;            // true if the vehicle is flying
     uint32_t    _sink_time_ms;           // system time that the vehicle exceeded critical sink rate
     uint32_t    _fall_time_ms;           // system time that the vehicle stated falling lower faster _min_accel


### PR DESCRIPTION
This re-factors the chute servo setting to start from and return to the PWM as set with the CUTE PWM param.