### PR TITLE
Copter: surface_tracking: default off

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -306,7 +306,7 @@ private:
         void set_surface(Surface new_surface);
 
     private:
-        Surface surface = Surface::GROUND;
+        Surface surface = Surface::NONE;
         float target_dist_cm;       // desired distance in cm from ground or ceiling
         uint32_t last_update_ms;    // system time of last update to target_alt_cm
         uint32_t last_glitch_cleared_ms;    // system time of last handle glitch recovery


### PR DESCRIPTION
This turns off surface tracing by default. 