### PR TITLE
Fix auto RTL double enter issue.

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -22,6 +22,7 @@
 // auto_init - initialise auto controller
 bool ModeAuto::init(bool ignore_checks)
 {
+    auto_RTL = false;
     if (mission.num_commands() > 1 || ignore_checks) {
         _mode = Auto_Loiter;
 
@@ -51,10 +52,6 @@ bool ModeAuto::init(bool ignore_checks)
             waiting_for_origin = false;
         } else {
             waiting_for_origin = true;
-        }
-
-        if (auto_RTL) {
-            mission.set_in_landing_sequence_flag(true);
         }
 
         return true;
@@ -151,7 +148,8 @@ bool ModeAuto::jump_to_landing_sequence_auto_RTL(ModeReason reason)
             mission.jump_to_landing_sequence()) {
 
         mission.set_force_resume(true);
-        if (set_mode(Mode::Number::AUTO, reason)) {
+        // if not already in auto then switch to auto
+        if ((copter.flightmode == &copter.mode_auto) || set_mode(Mode::Number::AUTO, reason)) {
             auto_RTL = true;
             return true;
         }


### PR DESCRIPTION
Looks like all of the issues were related to a double entry of Auto RTL leaving the mission in the stopped state. This both caused the copter to stop once it had got to the next waypoint and revert from Auto RTL back to auto. The fix is to only try switching to auto if we are not already in it. 

I am having trouble replicating the issue with the standby controller, hopefully this fixes that too. 