### PR TITLE
Tools: scripts: run_ride_allong: run each instance in own dir and don…

### DIFF
--- a/Tools/scripts/run_ride_allong.sh
+++ b/Tools/scripts/run_ride_allong.sh
@@ -4,8 +4,14 @@
 VEHICLE="ArduCopter"
 LOCATION="ParkDavis"
 
-x-terminal-emulator -e "sleep 5; ./Tools/autotest/sim_vehicle.py -w -v $VEHICLE -L $LOCATION -f json:0.0.0.0 -I1"
+mkdir -p 1
+cd 1
+x-terminal-emulator -e "sleep 5; ../Tools/autotest/sim_vehicle.py -v $VEHICLE -L $LOCATION -f json:0.0.0.0 -I1; $SHELL"
+cd ..
 
-x-terminal-emulator -e "sleep 2; ./Tools/autotest/sim_vehicle.py -w -v $VEHICLE -L $LOCATION -f json:0.0.0.0 -I2"
+mkdir -p 2
+cd 2
+x-terminal-emulator -e "sleep 2; ../Tools/autotest/sim_vehicle.py -v $VEHICLE -L $LOCATION -f json:0.0.0.0 -I2; $SHELL"
+cd ..
 
-./Tools/autotest/sim_vehicle.py -v $VEHICLE -L $LOCATION -w --console --map --slave 2
+./Tools/autotest/sim_vehicle.py -v $VEHICLE -L $LOCATION --console --map --slave 2


### PR DESCRIPTION
…'t reset params

Just makes is less painful to get everything in sync, running each in own directory means they don't share eeprom so don't do funny thing on restarts. That allows us to remove the pram wipe. `$SHELL` makes the thermals hang around so you can see the error that killed them.