### PR TITLE
Landing Re-start fix

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -124,7 +124,7 @@ void ModeAuto::run()
     }
 
     // only pretend to be in auto RTL so long as mission still thinks its in a landing sequence or the mission has completed
-    if (auto_RTL && (!(mission.get_in_landing_sequence_flag() || mission.state() == AP_Mission::mission_state::MISSION_COMPLETE))) {
+    if (auto_RTL && (!(mission.get_in_landing_sequence_flag() || mission.get_in_rejoin_sequence_flag() || mission.state() == AP_Mission::mission_state::MISSION_COMPLETE))) {
         auto_RTL = false;
         // log exit from Auto RTL
         copter.logger.Write_Mode((uint8_t)copter.flightmode->mode_number(), ModeReason::AUTO_RTL_EXIT);

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -178,6 +178,7 @@ void AP_Mission::reset()
     _flags.do_cmd_loaded   = false;
     _flags.do_cmd_all_done = false;
     _flags.in_landing_sequence = false;
+    _flags.in_rejoin_sequence = false;
     _nav_cmd.index         = AP_MISSION_CMD_INDEX_NONE;
     _do_cmd.index          = AP_MISSION_CMD_INDEX_NONE;
     _prev_nav_cmd_index    = AP_MISSION_CMD_INDEX_NONE;
@@ -287,6 +288,8 @@ bool AP_Mission::start_command(const Mission_Command& cmd)
     // check for landing related commands and set in_landing_sequence flag
     if (is_landing_type_cmd(cmd.id) || cmd.id == MAV_CMD_DO_LAND_START) {
         set_in_landing_sequence_flag(true);
+    } else if (cmd.id == MAV_CMD_DO_LAND_REJOIN) {
+        _flags.in_rejoin_sequence = true;
     }
 
     gcs().send_text(MAV_SEVERITY_INFO, "Mission: %u %s", cmd.index, cmd.type());
@@ -398,10 +401,16 @@ int32_t AP_Mission::get_next_ground_course_cd(int32_t default_angle)
 // set_current_cmd - jumps to command specified by index
 bool AP_Mission::set_current_cmd(uint16_t index)
 {
+    _flags.in_landing_sequence = false;
+    _flags.in_rejoin_sequence = false;
+
     // read command to check for DO_LAND_START
     Mission_Command cmd;
-    if (!read_cmd_from_storage(index, cmd) || (cmd.id != MAV_CMD_DO_LAND_START)) {
-        _flags.in_landing_sequence = false;
+    read_cmd_from_storage(index, cmd);
+    if (cmd.id == MAV_CMD_DO_LAND_START) {
+        _flags.in_landing_sequence = true;
+    } else if (cmd.id == MAV_CMD_DO_LAND_REJOIN) {
+        _flags.in_rejoin_sequence = true;
     }
 
     // sanity check index and that we have a mission
@@ -1473,6 +1482,7 @@ void AP_Mission::complete()
     // flag mission as complete
     _flags.state = MISSION_COMPLETE;
     _flags.in_landing_sequence = false;
+    _flags.in_rejoin_sequence = false;
 
     // callback to main program's mission complete function
     _mission_complete_fn();
@@ -1837,7 +1847,6 @@ bool AP_Mission::jump_to_landing_sequence(void)
         }
 
         gcs().send_text(MAV_SEVERITY_INFO, "Landing sequence start");
-        _flags.in_landing_sequence = true;
         return true;
     }
 
@@ -1896,7 +1905,6 @@ bool AP_Mission::jump_to_shortest_landing_sequence(void)
         }
 
         gcs().send_text(MAV_SEVERITY_INFO, "Shortest Landing sequence start");
-        _flags.in_landing_sequence = true;
         return true;
     }
 
@@ -1905,11 +1913,22 @@ bool AP_Mission::jump_to_shortest_landing_sequence(void)
 }
 
 /*
-   find the closest point on the mission after a DO_LAND_START and before the final DO_LAND_START
+   find the closest point on the mission after a DO_LAND_REJOIN and before the final DO_LAND_START
    defaults to closest if distance to mission calculation fails
  */
 bool AP_Mission::jump_to_closest_mission_leg(void)
 {
+    if (_flags.state == MISSION_RUNNING) {
+        // if mission is already running don't switch away from a active landing or rejoin
+        if (_flags.in_landing_sequence) {
+            gcs().send_text(MAV_SEVERITY_INFO, "Landing sequence active");
+            return true;
+        } else if (_flags.in_rejoin_sequence) {
+            gcs().send_text(MAV_SEVERITY_INFO, "Rejoin Landing sequence active");
+            return true;
+        }
+    }
+
     struct Location current_loc;
     if (!AP::ahrs().get_position(current_loc)) {
         return 0;
@@ -1939,7 +1958,7 @@ bool AP_Mission::jump_to_closest_mission_leg(void)
         }
 
         gcs().send_text(MAV_SEVERITY_INFO, "Rejoin Landing sequence start");
-        _flags.in_landing_sequence = true;
+        _flags.in_rejoin_sequence = true;
         return true;
     }
 
@@ -1948,12 +1967,23 @@ bool AP_Mission::jump_to_closest_mission_leg(void)
 }
 
 /*
-   find the closest point on the mission after a DO_LAND_START and before the final DO_LAND_START
+   find the closest point on the mission after a DO_LAND_REJOIN and before the final DO_LAND_START
    pick the shortest distance to landing not the shortest distance to rejoin mission
    defaults to closest if distance to landing calculation fails
  */
 bool AP_Mission::jump_to_shortest_mission_leg(void)
 {
+    if (_flags.state == MISSION_RUNNING) {
+        // if mission is already running don't switch away from a active landing or rejoin
+        if (_flags.in_landing_sequence) {
+            gcs().send_text(MAV_SEVERITY_INFO, "Landing sequence active");
+            return true;
+        } else if (_flags.in_rejoin_sequence) {
+            gcs().send_text(MAV_SEVERITY_INFO, "Rejoin Landing sequence active");
+            return true;
+        }
+    }
+
     struct Location current_loc;
     if (!AP::ahrs().get_position(current_loc)) {
         return 0;
@@ -1983,7 +2013,7 @@ bool AP_Mission::jump_to_shortest_mission_leg(void)
         }
 
         gcs().send_text(MAV_SEVERITY_INFO, "Rejoin shortest Landing sequence start");
-        _flags.in_landing_sequence = true;
+        _flags.in_rejoin_sequence = true;
         return true;
     }
 
@@ -2024,6 +2054,7 @@ bool AP_Mission::jump_to_abort_landing_sequence(void)
         }
 
         _flags.in_landing_sequence = false;
+        _flags.in_rejoin_sequence = false;
 
         gcs().send_text(MAV_SEVERITY_INFO, "Landing abort sequence start");
         return true;

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -505,6 +505,11 @@ public:
         return _flags.in_landing_sequence;
     }
 
+    // get in_rejoin_sequence flag
+    bool get_in_rejoin_sequence_flag() const {
+        return _flags.in_rejoin_sequence;
+    }
+
     // get a reference to the AP_Mission semaphore, allowing an external caller to lock the
     // storage while working with multiple waypoints
     HAL_Semaphore_Recursive &get_semaphore(void) {
@@ -533,6 +538,7 @@ private:
         uint8_t do_cmd_loaded   : 1; // true if a "do"/"conditional" command has been loaded into _do_cmd
         uint8_t do_cmd_all_done : 1; // true if all "do"/"conditional" commands have been completed (stops unnecessary searching through eeprom for do commands)
         bool in_landing_sequence  : 1; // true if the mission has jumped to a landing
+        bool in_rejoin_sequence : 1; // true if the misison has passed a rejoin, or rejoined
     } _flags;
 
     ///


### PR DESCRIPTION
This stops a second attempt at doing a land re-join resetting the current nav command, instead it will just carry on.