### PR TITLE
Copter: set_mode_auto_do_land_start_or_RTL via set_mode

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -345,7 +345,8 @@ void Copter::set_mode_SmartRTL_or_RTL(ModeReason reason)
 // This can come from failsafe or RC option
 void Copter::set_mode_auto_do_land_start_or_RTL(ModeReason reason)
 {
-    if (copter.mode_auto.jump_to_landing_sequence_auto_RTL(reason)) {
+    if (set_mode(Mode::Number::AUTO_RTL, reason)) {
+        AP_Notify::events.failsafe_mode_change = 1;
         return;
     }
 


### PR DESCRIPTION
Change to use `set_mode` means we don't re-enter if already in auto RTL.