### PR TITLE
Auto RTL fixups

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -146,7 +146,7 @@ void ModeAuto::run()
     }
 
     // only pretend to be in auto RTL so long as mission still thinks its in a landing sequence or the mission has completed
-    if (auto_RTL && (!(mission.get_in_landing_sequence_flag() || mission.state() == AP_Mission::mission_state::MISSION_COMPLETE))) {
+    if (auto_RTL && (!(mission.get_in_landing_sequence_flag() || mission.get_in_rejoin_sequence_flag() || mission.state() == AP_Mission::mission_state::MISSION_COMPLETE))) {
         auto_RTL = false;
         // log exit from Auto RTL
         copter.logger.Write_Mode((uint8_t)copter.flightmode->mode_number(), ModeReason::AUTO_RTL_EXIT);

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -161,10 +161,16 @@ bool ModeAuto::allows_arming(AP_Arming::Method method) const
 // Go straight to landing sequence via DO_LAND_START, if succeeds pretend to be Auto RTL mode
 bool ModeAuto::jump_to_landing_sequence_auto_RTL(ModeReason reason)
 {
-    if ( ((g2.auto_rtl_type == 3) && mission.jump_to_shortest_landing_sequence()) ||
-         ((g2.auto_rtl_type == 4) && mission.jump_to_closest_mission_leg()) ||
-         ((g2.auto_rtl_type == 5) && mission.jump_to_shortest_mission_leg()) || 
-            mission.jump_to_landing_sequence()) {
+    // Use stopping point as location for start of auto RTL
+    Vector3p stopping_point_NEU;
+    copter.pos_control->get_stopping_point_xy_cm(stopping_point_NEU.xy());
+    copter.pos_control->get_stopping_point_z_cm(stopping_point_NEU.z);
+    Location stopping_point {stopping_point_NEU, Location::AltFrame::ABOVE_HOME};
+
+    if ( ((g2.auto_rtl_type == 3) && mission.jump_to_shortest_landing_sequence(stopping_point)) ||
+         ((g2.auto_rtl_type == 4) && mission.jump_to_closest_mission_leg(stopping_point)) ||
+         ((g2.auto_rtl_type == 5) && mission.jump_to_shortest_mission_leg(stopping_point)) || 
+            mission.jump_to_landing_sequence(stopping_point)) {
 
         mission.set_force_resume(true);
         // if not already in auto then switch to auto

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1993,14 +1993,8 @@ uint16_t AP_Mission::num_commands_max(void) const
 // find the nearest landing sequence starting point (DO_LAND_START) and
 // return its index.  Returns 0 if no appropriate DO_LAND_START point can
 // be found.
-uint16_t AP_Mission::get_landing_sequence_start()
+uint16_t AP_Mission::get_landing_sequence_start(struct Location start_loc)
 {
-    struct Location current_loc;
-
-    if (!AP::ahrs().get_position(current_loc)) {
-        return 0;
-    }
-
     uint16_t landing_start_index = 0;
     float min_distance = -1;
 
@@ -2015,7 +2009,7 @@ uint16_t AP_Mission::get_landing_sequence_start()
                 // command does not have a valid location and cannot get next valid
                 continue;
             }
-            float tmp_distance = tmp.content.location.get_distance(current_loc);
+            float tmp_distance = tmp.content.location.get_distance(start_loc);
             if (min_distance < 0 || tmp_distance < min_distance) {
                 min_distance = tmp_distance;
                 landing_start_index = i;
@@ -2031,9 +2025,9 @@ uint16_t AP_Mission::get_landing_sequence_start()
    switch to that mission item.  Returns false if no DO_LAND_START
    available.
  */
-bool AP_Mission::jump_to_landing_sequence(void)
+bool AP_Mission::jump_to_landing_sequence(struct Location start_loc)
 {
-    uint16_t land_idx = get_landing_sequence_start();
+    uint16_t land_idx = get_landing_sequence_start(start_loc);
     if (land_idx != 0 && set_current_cmd(land_idx)) {
 
         //if the mission has ended it has to be restarted
@@ -2049,18 +2043,23 @@ bool AP_Mission::jump_to_landing_sequence(void)
     return false;
 }
 
+bool AP_Mission::jump_to_landing_sequence(void)
+{
+    struct Location current_loc;
+    if (!AP::ahrs().get_position(current_loc)) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Unable to start landing sequence");
+        return false;
+    }
+    return jump_to_landing_sequence(current_loc);
+}
+
 /*
    find the shortest distance to landing via DO_LAND_START and
    return its index.  Returns 0 if no appropriate DO_LAND_START point can
    be found.
 */
-uint16_t AP_Mission::get_shortest_landing_sequence_start()
+uint16_t AP_Mission::get_shortest_landing_sequence_start(struct Location start_loc)
 {
-    struct Location current_loc;
-    if (!AP::ahrs().get_position(current_loc)) {
-        return 0;
-    }
-
     uint16_t landing_start_index = 0;
     float min_distance = -1;
 
@@ -2072,7 +2071,7 @@ uint16_t AP_Mission::get_shortest_landing_sequence_start()
         }
         if (tmp.id == MAV_CMD_DO_LAND_START) {
             float tmp_distance;
-            if (!distance_to_landing(i, tmp_distance, current_loc)){
+            if (!distance_to_landing(i, tmp_distance, start_loc)){
                 continue;
             }
             if (min_distance < 0 || tmp_distance < min_distance) {
@@ -2084,14 +2083,23 @@ uint16_t AP_Mission::get_shortest_landing_sequence_start()
     return landing_start_index;
 }
 
+uint16_t AP_Mission::get_shortest_landing_sequence_start()
+{
+    struct Location current_loc;
+    if (!AP::ahrs().get_position(current_loc)) {
+        return 0;
+    }
+    return get_shortest_landing_sequence_start(current_loc);
+}
+
 
 /*
    find the landing sequence starting point (DO_LAND_START) that will result in the shortest distance to a landing
    defaults to closest if distance to landing calculation fails
  */
-bool AP_Mission::jump_to_shortest_landing_sequence(void)
+bool AP_Mission::jump_to_shortest_landing_sequence(struct Location start_loc)
 {
-    uint16_t landing_start_index = get_shortest_landing_sequence_start();
+    uint16_t landing_start_index = get_shortest_landing_sequence_start(start_loc);
     if (landing_start_index != 0 && set_current_cmd(landing_start_index)) {
 
         // if the mission has ended it has to be restarted
@@ -2107,11 +2115,20 @@ bool AP_Mission::jump_to_shortest_landing_sequence(void)
     return jump_to_landing_sequence();
 }
 
+bool AP_Mission::jump_to_shortest_landing_sequence(void)
+{
+    struct Location current_loc;
+    if (!AP::ahrs().get_position(current_loc)) {
+        return false;
+    }
+    return jump_to_shortest_landing_sequence(current_loc);
+}
+
 /*
    find the closest point on the mission after a DO_LAND_REJOIN and before the final DO_LAND_START
    defaults to closest if distance to mission calculation fails
  */
-bool AP_Mission::jump_to_closest_mission_leg(void)
+bool AP_Mission::jump_to_closest_mission_leg(struct Location start_loc)
 {
     if (_flags.state == MISSION_RUNNING) {
         // if mission is already running don't switch away from a active landing or rejoin
@@ -2124,11 +2141,6 @@ bool AP_Mission::jump_to_closest_mission_leg(void)
         }
     }
 
-    struct Location current_loc;
-    if (!AP::ahrs().get_position(current_loc)) {
-        return 0;
-    }
-
     uint16_t landing_start_index = 0;
     float min_distance = -1;
 
@@ -2138,7 +2150,7 @@ bool AP_Mission::jump_to_closest_mission_leg(void)
         if (read_cmd_from_storage(i, tmp) && (tmp.id == MAV_CMD_DO_LAND_REJOIN)) {
             uint16_t tmp_index;
             float tmp_distance;
-            if (distance_to_mission_leg(i, tmp_distance, tmp_index, current_loc) && (min_distance < 0 || tmp_distance <= min_distance)){
+            if (distance_to_mission_leg(i, tmp_distance, tmp_index, start_loc) && (min_distance < 0 || tmp_distance <= min_distance)){
                 min_distance = tmp_distance;
                 landing_start_index = tmp_index;
             }
@@ -2161,12 +2173,21 @@ bool AP_Mission::jump_to_closest_mission_leg(void)
     return jump_to_landing_sequence();
 }
 
+bool AP_Mission::jump_to_closest_mission_leg(void)
+{
+    struct Location current_loc;
+    if (!AP::ahrs().get_position(current_loc)) {
+        return false;
+    }
+    return jump_to_closest_mission_leg(current_loc);
+}
+
 /*
    find the closest point on the mission after a DO_LAND_REJOIN and before the final DO_LAND_START
    pick the shortest distance to landing not the shortest distance to rejoin mission
    defaults to closest if distance to landing calculation fails
  */
-bool AP_Mission::jump_to_shortest_mission_leg(void)
+bool AP_Mission::jump_to_shortest_mission_leg(struct Location start_loc)
 {
     if (_flags.state == MISSION_RUNNING) {
         // if mission is already running don't switch away from a active landing or rejoin
@@ -2179,11 +2200,6 @@ bool AP_Mission::jump_to_shortest_mission_leg(void)
         }
     }
 
-    struct Location current_loc;
-    if (!AP::ahrs().get_position(current_loc)) {
-        return 0;
-    }
-
     uint16_t landing_start_index = 0;
     float min_distance = -1;
 
@@ -2193,7 +2209,7 @@ bool AP_Mission::jump_to_shortest_mission_leg(void)
         if (read_cmd_from_storage(i, tmp) && (tmp.id == MAV_CMD_DO_LAND_REJOIN)) {
             uint16_t tmp_index;
             float tmp_distance;
-            if (distance_to_mission_leg(i, tmp_distance, tmp_index, current_loc) && distance_to_landing(tmp_index, tmp_distance, current_loc) && (min_distance < 0 || tmp_distance <= min_distance)) {
+            if (distance_to_mission_leg(i, tmp_distance, tmp_index, start_loc) && distance_to_landing(tmp_index, tmp_distance, start_loc) && (min_distance < 0 || tmp_distance <= min_distance)) {
                 min_distance = tmp_distance;
                 landing_start_index = tmp_index;
             }
@@ -2216,27 +2232,31 @@ bool AP_Mission::jump_to_shortest_mission_leg(void)
     return jump_to_closest_mission_leg();
 }
 
-
-// jumps the mission to the closest landing abort that is planned, returns false if unable to find a valid abort
-bool AP_Mission::jump_to_abort_landing_sequence(void)
+bool AP_Mission::jump_to_shortest_mission_leg(void)
 {
     struct Location current_loc;
+    if (!AP::ahrs().get_position(current_loc)) {
+        return false;
+    }
+    return jump_to_shortest_mission_leg(current_loc);
+}
 
-    uint16_t abort_index = 0;
-    if (AP::ahrs().get_position(current_loc)) {
-        float min_distance = FLT_MAX;
+// jumps the mission to the closest landing abort that is planned, returns false if unable to find a valid abort
+bool AP_Mission::jump_to_abort_landing_sequence(struct Location start_loc)
+{
+   uint16_t abort_index = 0;
+    float min_distance = FLT_MAX;
 
-        for (uint16_t i = 1; i < num_commands(); i++) {
-            Mission_Command tmp;
-            if (!read_cmd_from_storage(i, tmp)) {
-                continue;
-            }
-            if (tmp.id == MAV_CMD_DO_GO_AROUND) {
-                float tmp_distance = tmp.content.location.get_distance(current_loc);
-                if (tmp_distance < min_distance) {
-                    min_distance = tmp_distance;
-                    abort_index = i;
-                }
+    for (uint16_t i = 1; i < num_commands(); i++) {
+        Mission_Command tmp;
+        if (!read_cmd_from_storage(i, tmp)) {
+            continue;
+        }
+        if (tmp.id == MAV_CMD_DO_GO_AROUND) {
+            float tmp_distance = tmp.content.location.get_distance(start_loc);
+            if (tmp_distance < min_distance) {
+                min_distance = tmp_distance;
+                abort_index = i;
             }
         }
     }
@@ -2258,6 +2278,17 @@ bool AP_Mission::jump_to_abort_landing_sequence(void)
     gcs().send_text(MAV_SEVERITY_WARNING, "Unable to start find a landing abort sequence");
     return false;
 }
+
+bool AP_Mission::jump_to_abort_landing_sequence(void)
+{
+    struct Location current_loc;
+    if (!AP::ahrs().get_position(current_loc)) {
+        gcs().send_text(MAV_SEVERITY_WARNING, "Unable to start find a landing abort sequence");
+        return false;
+    }
+    return jump_to_abort_landing_sequence(current_loc);
+}
+
 
 // check which is the shortest route to landing an RTL via a DO_LAND_START or continuing on the current mission plan
 bool AP_Mission::is_best_land_sequence(void)

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -532,29 +532,35 @@ public:
     // find the nearest landing sequence starting point (DO_LAND_START) and
     // return its index.  Returns 0 if no appropriate DO_LAND_START point can
     // be found.
-    uint16_t get_landing_sequence_start();
+    uint16_t get_landing_sequence_start(struct Location start_loc);
 
     // find the shortest distance to landing via DO_LAND_START and
     // return its index.  Returns 0 if no appropriate DO_LAND_START point can
     // be found.
     uint16_t get_shortest_landing_sequence_start();
+    uint16_t get_shortest_landing_sequence_start(struct Location start_loc);
 
     // find the nearest landing sequence starting point (DO_LAND_START) and
     // switch to that mission item.  Returns false if no DO_LAND_START
     // available.
     bool jump_to_landing_sequence(void);
+    bool jump_to_landing_sequence(struct Location start_loc);
 
     // find the landing sequence starting point (DO_LAND_START) that will result in the shortest distance to a landing
     bool jump_to_shortest_landing_sequence(void);
+    bool jump_to_shortest_landing_sequence(struct Location start_loc);
 
     // find the closest point on the mission after a DO_LAND_START and before the final DO_LAND_START
     bool jump_to_closest_mission_leg(void);
+    bool jump_to_closest_mission_leg(struct Location start_loc);
 
     // pick the shortest distance to landing not the shortest distance to rejoin mission
     bool jump_to_shortest_mission_leg(void);
+    bool jump_to_shortest_mission_leg(struct Location start_loc);
 
     // jumps the mission to the closest landing abort that is planned, returns false if unable to find a valid abort
     bool jump_to_abort_landing_sequence(void);
+    bool jump_to_abort_landing_sequence(struct Location start_loc);
 
     // check which is the shortest route to landing an RTL via a DO_LAND_START or continuing on the current mission plan
     bool is_best_land_sequence(void);


### PR DESCRIPTION
This fixes a couple of issues in AutoRTL. Two fixes that got lost in the move from 4.0. One fix that should be backported to 4.0. 

The 3D distance calculation will result in a NAN if there are two consecutive points as the same location. This should not matter IRL but will crash SITL. The fix is just to check the vector is 0: `if (!mission_vector.is_zero()) {`.

This also allows us to pass a location to be used as the starting point for the distance calculations in place of the current location. Copter then passes in the stopping point, this prevents the vehicle heading back to a point because it could not slow down fast enough to hit it directly. 