### PR TITLE
4.0.5 AutoRTL re-join stopping point

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -144,10 +144,17 @@ bool ModeAuto::allows_weathervaning(void) const
 // Go straight to landing sequence via DO_LAND_START, if succeeds pretend to be Auto RTL mode
 bool ModeAuto::jump_to_landing_sequence_auto_RTL(ModeReason reason)
 {
-    if ( ((g2.auto_rtl_type == 3) && mission.jump_to_shortest_landing_sequence()) ||
-         ((g2.auto_rtl_type == 4) && mission.jump_to_closest_mission_leg()) ||
-         ((g2.auto_rtl_type == 5) && mission.jump_to_shortest_mission_leg()) || 
-            mission.jump_to_landing_sequence()) {
+    // Use stopping point as location for start of auto RTL
+    Vector3f stopping_point_NEU;
+    copter.pos_control->get_stopping_point_xy(stopping_point_NEU);
+    copter.pos_control->get_stopping_point_z(stopping_point_NEU);
+    Location stopping_point {stopping_point_NEU};
+    stopping_point.change_alt_frame(Location::AltFrame::ABOVE_HOME);
+
+    if ( ((g2.auto_rtl_type == 3) && mission.jump_to_shortest_landing_sequence(stopping_point)) ||
+         ((g2.auto_rtl_type == 4) && mission.jump_to_closest_mission_leg(stopping_point)) ||
+         ((g2.auto_rtl_type == 5) && mission.jump_to_shortest_mission_leg(stopping_point)) || 
+            mission.jump_to_landing_sequence(stopping_point)) {
 
         mission.set_force_resume(true);
         // if not already in auto then switch to auto

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2049,7 +2049,7 @@ bool AP_Mission::jump_to_shortest_mission_leg(void)
 // jumps the mission to the closest landing abort that is planned, returns false if unable to find a valid abort
 bool AP_Mission::jump_to_abort_landing_sequence(struct Location start_loc)
 {
-   uint16_t abort_index = 0;
+    uint16_t abort_index = 0;
     float min_distance = FLT_MAX;
 
     for (uint16_t i = 1; i < num_commands(); i++) {

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2215,7 +2215,6 @@ bool AP_Mission::distance_to_mission_leg(uint16_t start_index, float &rejoin_dis
         index = temp_cmd.index + 1;
 
         if (stored_in_location(temp_cmd.id) && temp_cmd.content.location.initialised()) {
-            ret = true;
             if (prev_loc.lat == 0 && prev_loc.lng == 0) {
                 // Need a valid previous location to do distance to leg calculation
                 prev_loc = temp_cmd.content.location;
@@ -2223,28 +2222,32 @@ bool AP_Mission::distance_to_mission_leg(uint16_t start_index, float &rejoin_dis
                 // single point dist calc
                 rejoin_distance = prev_loc.get_distance_NED_alt_frame(current_loc).length();
                 rejoin_index = temp_cmd.index;
+                ret = true;
 
             } else {
                 // Calculate the distance to rejoin
                 Vector3f mission_vector = prev_loc.get_distance_NED_alt_frame(temp_cmd.content.location);
-                Vector3f pos = prev_loc.get_distance_NED_alt_frame(current_loc);
+                if (!mission_vector.is_zero()) {
+                    Vector3f pos = prev_loc.get_distance_NED_alt_frame(current_loc);
 
-                // project pos vector on to mission vector
-                Vector3f p = pos.projected(mission_vector);
+                    // project pos vector on to mission vector
+                    Vector3f p = pos.projected(mission_vector);
 
-                // constrain to mission line
-                p.x = constrain_float(p.x, MIN(0,mission_vector.x), MAX(0,mission_vector.x));
-                p.y = constrain_float(p.y, MIN(0,mission_vector.y), MAX(0,mission_vector.y));
-                p.z = constrain_float(p.z, MIN(0,mission_vector.z), MAX(0,mission_vector.z));
+                    // constrain to mission line
+                    p.x = constrain_float(p.x, MIN(0,mission_vector.x), MAX(0,mission_vector.x));
+                    p.y = constrain_float(p.y, MIN(0,mission_vector.y), MAX(0,mission_vector.y));
+                    p.z = constrain_float(p.z, MIN(0,mission_vector.z), MAX(0,mission_vector.z));
 
-                float disttemp = (p - pos).length();
+                    float disttemp = (p - pos).length();
 
-                // store wp location as previous
-                prev_loc = temp_cmd.content.location;
+                    // store wp location as previous
+                    prev_loc = temp_cmd.content.location;
 
-                if (disttemp < rejoin_distance || is_negative(rejoin_distance)) {
-                    rejoin_distance = disttemp;
-                    rejoin_index = temp_cmd.index;
+                    if (disttemp < rejoin_distance || is_negative(rejoin_distance)) {
+                        rejoin_distance = disttemp;
+                        rejoin_index = temp_cmd.index;
+                    }
+                    ret = true;
                 }
             }
         }

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -464,29 +464,35 @@ public:
     // find the nearest landing sequence starting point (DO_LAND_START) and
     // return its index.  Returns 0 if no appropriate DO_LAND_START point can
     // be found.
-    uint16_t get_landing_sequence_start();
+    uint16_t get_landing_sequence_start(struct Location start_loc);
 
     // find the shortest distance to landing via DO_LAND_START and
     // return its index.  Returns 0 if no appropriate DO_LAND_START point can
     // be found.
     uint16_t get_shortest_landing_sequence_start();
+    uint16_t get_shortest_landing_sequence_start(struct Location start_loc);
 
     // find the nearest landing sequence starting point (DO_LAND_START) and
     // switch to that mission item.  Returns false if no DO_LAND_START
     // available.
     bool jump_to_landing_sequence(void);
+    bool jump_to_landing_sequence(struct Location start_loc);
 
     // find the landing sequence starting point (DO_LAND_START) that will result in the shortest distance to a landing
     bool jump_to_shortest_landing_sequence(void);
+    bool jump_to_shortest_landing_sequence(struct Location start_loc);
 
     // find the closest point on the mission after a DO_LAND_START and before the final DO_LAND_START
     bool jump_to_closest_mission_leg(void);
+    bool jump_to_closest_mission_leg(struct Location start_loc);
 
     // pick the shortest distance to landing not the shortest distance to rejoin mission
     bool jump_to_shortest_mission_leg(void);
+    bool jump_to_shortest_mission_leg(struct Location start_loc);
 
     // jumps the mission to the closest landing abort that is planned, returns false if unable to find a valid abort
     bool jump_to_abort_landing_sequence(void);
+    bool jump_to_abort_landing_sequence(struct Location start_loc);
 
     // force mission to resume when start_or_resume() is called
     void set_force_resume(bool force_resume) { _force_resume = force_resume; }


### PR DESCRIPTION
Back port of https://github.com/m4a3/ardupilot/pull/60, main enhancement is using the stopping point, this should eliminate going back to a waypoint when AUTO RTL is entered just before auto reaches a waypoint. 