### PR TITLE
Weathervane is only allowed to override default yaw mode

### DIFF
--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -260,6 +260,11 @@ void Mode::AutoYaw::update_weathervane(const int16_t roll_cdeg, const int16_t pi
 #if WEATHERVANE_ENABLED == ENABLED
     if (copter.g2.weathervane.should_weathervane(roll_cdeg, pitch_cdeg, pilot_yaw, (float)hgt_cm*0.01)) {
         if (mode() != AUTO_YAW_WEATHERVANE) {
+            if (mode() != default_mode(false)) {
+                // only override the default mode
+                copter.g2.weathervane.reset();
+                return;
+            }
             set_mode(AUTO_YAW_WEATHERVANE);
         }
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4074,16 +4074,13 @@ class AutoTestCopter(AutoTest):
         self.change_mode("GUIDED")
 
         # After take off command in guided we enter the velaccl sub mode
-        self.progress("Test weathervaning in guided vel-accel")
+        self.progress("Test weathervaning in guided pos only")
         self.set_rc(3, 1000)
         self.wait_ready_to_arm()
 
         self.arm_vehicle()
         self.user_takeoff(alt_min=15)
-        # Wait for heading to match wind direction.
-        self.wait_heading(100, accuracy=8, timeout=100)
 
-        self.progress("Test weathervaning in guided pos only")
         # Travel directly north to align heading north and build some airspeed.
         self.fly_guided_move_local(x=40, y=0, z_up=15)
         # Wait for heading to match wind direction.

--- a/libraries/AC_AttitudeControl/AC_WeatherVane.h
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.h
@@ -19,6 +19,9 @@ class AC_WeatherVane {
         // Use to relax weathervaning on landing.  Must be persistently called before calls to get_weathervane_yaw_rate_cds().
         void set_relax(bool relax) { should_relax = relax; }
 
+        // Function to reset all flags and set values. Invoked whenever the weather vaning process is interupted
+        void reset(void);
+
         static const struct AP_Param::GroupInfo var_info[];
 
     private:
@@ -33,9 +36,6 @@ class AC_WeatherVane {
 
         // Returns the set direction, handling the variable cast to type Direction
         Direction get_direction() const { return (Direction)_direction.get(); }
-
-        // Function to reset all flags and set values. Invoked whenever the weather vaning process is interupted
-        void reset(void);
 
         // Paramaters
         AP_Int8 _direction;


### PR DESCRIPTION
This stops weathervane from overriding a condition yaw waypoint. 