### PR TITLE
Copter: auto landing: skip reposition if within waypoint radius

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1309,12 +1309,27 @@ void ModeAuto::do_land(const AP_Mission::Mission_Command& cmd)
 
     // if location provided we fly to that location at current altitude
     if (cmd.content.location.lat != 0 || cmd.content.location.lng != 0) {
-        // set state to fly to location
-        state = State::FlyToLocation;
-
         const Location target_loc = terrain_adjusted_location(cmd);
+        if (target_loc.get_distance_NE(copter.current_loc).length_squared() < sq(copter.wp_nav->get_wp_radius_cm() * 0.01)) {
+            // within waypoint radius, skip reposition
 
-        wp_start(target_loc);
+            // convert location to NE vector2f
+            Vector2f dest;
+            if (!target_loc.get_vector_xy_from_origin_NE(dest)) {
+                return;
+            }
+
+            // initialise landing controller
+            land_start(dest);
+
+            // advance to next state
+            state = State::Descending;
+        } else {
+            // set state to fly to location
+            state = State::FlyToLocation;
+
+            wp_start(target_loc);
+        }
     } else {
         // set landing state
         state = State::Descending;

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -143,6 +143,9 @@ public:
         return get_wp_distance_to_destination() < _wp_radius_cm;
     }
 
+    // get wp_radius parameter value in cm
+    float get_wp_radius_cm() const { return _wp_radius_cm; }
+
     /// update_wpnav - run the wp controller - should be called at 100hz or higher
     virtual bool update_wpnav();
 


### PR DESCRIPTION
Skips the `FlyToLocation` stage if already within the waypoint radius, this stop us creating very short SCurve segments that take too long to complete. 